### PR TITLE
Rename BlockSize constants for readability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Unreleased
+
+## `gpt_disk_types`
+
+* Renamed the `BlockSize` constants: `B512`→`BS_512` and
+  `B4096`→`BS_4096`. The previous names were a little hard to read.

--- a/gpt_disk_io/examples/reader.rs
+++ b/gpt_disk_io/examples/reader.rs
@@ -35,7 +35,7 @@ fn main() -> Result<()> {
 
     let mut block_buf = vec![0u8; 512];
 
-    let block_io = StdBlockIo::new(&mut file, BlockSize::B512);
+    let block_io = StdBlockIo::new(&mut file, BlockSize::BS_512);
     let mut disk = Disk::new(block_io)?;
 
     let primary_header = disk.read_primary_gpt_header(&mut block_buf)?;

--- a/gpt_disk_io/src/lib.rs
+++ b/gpt_disk_io/src/lib.rs
@@ -47,7 +47,7 @@
 //! let mut disk_storage = vec![0; 4 * 1024 * 1024];
 //!
 //! // Standard 512-byte block size.
-//! let bs = BlockSize::B512;
+//! let bs = BlockSize::BS_512;
 //!
 //! // `MutSliceBlockIo` implements the `BlockIo` trait which is used by
 //! // the `Disk` type for reading and writing.

--- a/gpt_disk_io/src/std_support.rs
+++ b/gpt_disk_io/src/std_support.rs
@@ -30,7 +30,7 @@ use std::io::{self, Read, Seek, SeekFrom, Write};
 /// use std::fs::File;
 ///
 /// let mut file = File::open("some/disk")?;
-/// let block_io = StdBlockIo::new(&mut file, BlockSize::B512);
+/// let block_io = StdBlockIo::new(&mut file, BlockSize::BS_512);
 ///
 /// let mut block_buf = vec![0u8; 512];
 /// let mut disk = Disk::new(block_io)?;

--- a/gpt_disk_io/tests/test_block_io.rs
+++ b/gpt_disk_io/tests/test_block_io.rs
@@ -117,20 +117,20 @@ fn test_slice_block_io() -> Result<()> {
     data[512] = 3;
     data[1023] = 4;
 
-    let bio = SliceBlockIo::new(&mut data, BlockSize::B512);
+    let bio = SliceBlockIo::new(&mut data, BlockSize::BS_512);
     test_block_io_read(bio).unwrap();
 
-    let bio = MutSliceBlockIo::new(&mut data, BlockSize::B512);
+    let bio = MutSliceBlockIo::new(&mut data, BlockSize::BS_512);
     test_block_io_read(bio).unwrap();
 
-    test_block_io_write1(MutSliceBlockIo::new(&mut data, BlockSize::B512))
+    test_block_io_write1(MutSliceBlockIo::new(&mut data, BlockSize::BS_512))
         .unwrap();
     assert_eq!(data[0], 5);
     assert_eq!(data[511], 6);
     assert_eq!(data[512], 7);
     assert_eq!(data[1023], 8);
 
-    test_block_io_write2(MutSliceBlockIo::new(&mut data, BlockSize::B512))
+    test_block_io_write2(MutSliceBlockIo::new(&mut data, BlockSize::BS_512))
         .unwrap();
     assert_eq!(data[512], 9);
     assert_eq!(data[1023], 10);
@@ -153,13 +153,13 @@ fn test_std_block_io() -> Result<()> {
         data[1023] = 4;
 
         let mut cursor = Cursor::new(data);
-        test_block_io_read(StdBlockIo::new(&mut cursor, BlockSize::B512))
+        test_block_io_read(StdBlockIo::new(&mut cursor, BlockSize::BS_512))
             .unwrap();
     };
 
     {
         let mut cursor = Cursor::new(empty.clone());
-        test_block_io_write1(StdBlockIo::new(&mut cursor, BlockSize::B512))
+        test_block_io_write1(StdBlockIo::new(&mut cursor, BlockSize::BS_512))
             .unwrap();
         let data = cursor.into_inner();
         assert_eq!(data.len(), 512 * 3);
@@ -171,7 +171,7 @@ fn test_std_block_io() -> Result<()> {
 
     {
         let mut cursor = Cursor::new(empty.clone());
-        test_block_io_write2(StdBlockIo::new(&mut cursor, BlockSize::B512))
+        test_block_io_write2(StdBlockIo::new(&mut cursor, BlockSize::BS_512))
             .unwrap();
         let data = cursor.into_inner();
         assert_eq!(data.len(), 512 * 3);

--- a/gpt_disk_io/tests/test_disk.rs
+++ b/gpt_disk_io/tests/test_disk.rs
@@ -86,7 +86,7 @@ fn test_disk_write<Io>(block_io: Io) -> Result<(), DiskError<Io::Error>>
 where
     Io: BlockIo,
 {
-    let bs = BlockSize::B512;
+    let bs = BlockSize::BS_512;
     let mut block_buf = vec![0u8; bs.to_usize().unwrap()];
     let mut disk = Disk::new(block_io)?;
 
@@ -118,12 +118,12 @@ fn test_with_mut_slice(test_disk: &[u8]) -> Result<()> {
     let mut contents = test_disk.to_vec();
 
     // Test read.
-    test_disk_read(MutSliceBlockIo::new(&mut contents, BlockSize::B512))
+    test_disk_read(MutSliceBlockIo::new(&mut contents, BlockSize::BS_512))
         .unwrap();
 
     // Test write.
     let mut new_contents = vec![0; contents.len()];
-    test_disk_write(MutSliceBlockIo::new(&mut new_contents, BlockSize::B512))
+    test_disk_write(MutSliceBlockIo::new(&mut new_contents, BlockSize::BS_512))
         .unwrap();
     assert_eq!(contents, new_contents);
 
@@ -135,12 +135,12 @@ fn test_with_filelike(test_disk: &[u8]) -> Result<()> {
     let mut test_disk_cursor = Cursor::new(test_disk.to_vec());
 
     // Test read.
-    test_disk_read(StdBlockIo::new(&mut test_disk_cursor, BlockSize::B512))?;
+    test_disk_read(StdBlockIo::new(&mut test_disk_cursor, BlockSize::BS_512))?;
 
     // Test write.
     let mut new_disk = vec![0; 4 * 1024 * 1024];
     let mut new_disk_cursor = Cursor::new(&mut new_disk);
-    test_disk_write(StdBlockIo::new(&mut new_disk_cursor, BlockSize::B512))?;
+    test_disk_write(StdBlockIo::new(&mut new_disk_cursor, BlockSize::BS_512))?;
     assert_eq!(new_disk, test_disk);
 
     Ok(())

--- a/gpt_disk_io/tests/test_partition_array.rs
+++ b/gpt_disk_io/tests/test_partition_array.rs
@@ -28,9 +28,11 @@ fn test_partition_entry_array_layout() {
         entry_size: GptPartitionEntrySize::new(256).unwrap(),
         num_entries: 128,
     };
-    assert_eq!(layout.num_blocks(BlockSize::B512).unwrap(), 64);
+    assert_eq!(layout.num_blocks(BlockSize::BS_512).unwrap(), 64);
     assert_eq!(
-        layout.num_bytes_rounded_to_block(BlockSize::B512).unwrap(),
+        layout
+            .num_bytes_rounded_to_block(BlockSize::BS_512)
+            .unwrap(),
         64 * 512
     );
     assert_eq!(layout.num_bytes_exact().unwrap(), 256 * 128);

--- a/gpt_disk_types/src/block.rs
+++ b/gpt_disk_types/src/block.rs
@@ -254,14 +254,14 @@ pub struct BlockSize(NonZeroU32);
 
 impl BlockSize {
     /// 512-byte block size.
-    pub const B512: Self = Self(if let Some(nz) = NonZeroU32::new(512) {
+    pub const BS_512: Self = Self(if let Some(nz) = NonZeroU32::new(512) {
         nz
     } else {
         unreachable!()
     });
 
     /// 4096-byte block size.
-    pub const B4096: Self = Self(if let Some(nz) = NonZeroU32::new(4096) {
+    pub const BS_4096: Self = Self(if let Some(nz) = NonZeroU32::new(4096) {
         nz
     } else {
         unreachable!()
@@ -309,7 +309,7 @@ impl BlockSize {
 
 impl Default for BlockSize {
     fn default() -> Self {
-        BlockSize::B512
+        BlockSize::BS_512
     }
 }
 


### PR DESCRIPTION
Renamed `B512`→`BS_512` and `B4096`→`BS_4096`. The previous names were a
little hard to read, too close to `8512` and `84096`.

Also added a changelog file.