### PR TITLE
Tests: move panic from high level callers into fns and drop anyhow dev dependency

### DIFF
--- a/gpt_disk_io/Cargo.toml
+++ b/gpt_disk_io/Cargo.toml
@@ -22,9 +22,6 @@ repository = "https://github.com/google/gpt-disk-rs"
 bytemuck = { version = "1.4.0", default-features = false }
 gpt_disk_types = { version = "0.15.0", path = "../gpt_disk_types", features = ["bytemuck"] }
 
-[dev-dependencies]
-anyhow = "1.0.0"
-
 [features]
 # See module docstring in src/lib.rs for details of what this feature does.
 std = ["gpt_disk_types/std"]

--- a/gpt_disk_io/examples/reader.rs
+++ b/gpt_disk_io/examples/reader.rs
@@ -8,10 +8,11 @@
 
 #[cfg(feature = "std")]
 use {
-    anyhow::Result,
     gpt_disk_io::gpt_disk_types::BlockSize,
     gpt_disk_io::{Disk, StdBlockIo},
-    std::{env, fs},
+    // dyn error::Error is used below as a generic error return, but could be
+    // substituted with Result from the 'anyhow' crate if desired.
+    std::{env, error, fs},
 };
 
 // To create a disk to test this you can use truncate and sgdisk. For example:
@@ -21,7 +22,7 @@ use {
 // cargo run --features=std --example reader disk.bin
 
 #[cfg(feature = "std")]
-fn main() -> Result<()> {
+fn main() -> Result<(), Box<dyn error::Error>> {
     let disk_path = env::args().nth(1).expect("one argument is required");
     println!("opening {} for reading", disk_path);
 

--- a/gpt_disk_io/src/std_support.rs
+++ b/gpt_disk_io/src/std_support.rs
@@ -18,7 +18,7 @@ use std::io::{self, Read, Seek, SeekFrom, Write};
 /// # Example
 ///
 /// ```no_run
-/// # fn main() -> anyhow::Result<()> {
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// use gpt_disk_io::gpt_disk_types::BlockSize;
 /// use gpt_disk_io::{Disk, StdBlockIo};
 /// use std::fs::File;


### PR DESCRIPTION
```
The following changes since commit e5211936f6ac4e2696a771d5f14cae7d982f9445:

  gpt_disk_io/tests: drop unnecessary bz2 disk archive (2023-06-09 19:04:44 -0400)

are available in the Git repository at:

  https://github.com/ddiss/gpt-disk-rs tests_move_panic_into_fns

for you to fetch changes up to e1de440328ca4fd6ec439edd79faec0a2467ff18:

  gpt_disk_io/examples: use dyn Error instead of anyhow (2023-06-13 14:35:10 +0200)

----------------------------------------------------------------
David Disseldorp (2):
      tests: panic on low-level error instead of in caller
      gpt_disk_io/examples: use dyn Error instead of anyhow

 gpt_disk_io/Cargo.toml             |  3 ---
 gpt_disk_io/examples/reader.rs     |  7 ++++---
 gpt_disk_io/tests/test_block_io.rs | 49 +++++++++++++++++--------------------------------
 gpt_disk_io/tests/test_disk.rs     | 53 +++++++++++++++++++++--------------------------------
 4 files changed, 42 insertions(+), 70 deletions(-)
```