### PR TITLE
uguid: Fix non-upper-case-globals linter warning

### DIFF
--- a/uguid/src/lib.rs
+++ b/uguid/src/lib.rs
@@ -139,7 +139,7 @@ macro_rules! guid {
     ($s:literal) => {{
         // Create a temporary const value to force an error in the input
         // to fail at compile time.
-        const g: $crate::Guid = $crate::Guid::parse_or_panic($s);
-        g
+        const G: $crate::Guid = $crate::Guid::parse_or_panic($s);
+        G
     }};
 }


### PR DESCRIPTION
Currently the guid! macro creates a const called `g`, this triggers the non-upper-case-globals lint:
https://doc.rust-lang.org/rustc/lints/listing/warn-by-default.html#non-upper-case-globals