### PR TITLE
ci: Use codecov API token

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -108,6 +108,8 @@ jobs:
         with:
           files: lcov.info
           fail_ci_if_error: true
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   spellcheck:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
Codecov doesn't require an API token for public repos, but sometimes this leads to errors due to rate limiting:
https://community.codecov.com/t/upload-issues-unable-to-locate-build-via-github-actions-api/3954

Per the suggestions there, switch the token to using a secret configured in the github repo settings.