### PR TITLE
ci: Only build in MSRV job, don't run tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,7 +32,7 @@ jobs:
       - run: rustup default $rust_version
       - uses: Swatinem/rust-cache@v2
       - run: rustc --version
-      - run: cargo test --all-features
+      - run: cargo build -p uguid -p gpt_disk_types -p gpt_disk_io --all-features
 
   check:
     name: Check


### PR DESCRIPTION
This allows test-only dependencies to require a higher MSRV.