### PR TITLE
gpt_disk_io: Fix a warning in a test

### DIFF
--- a/gpt_disk_io/tests/common/mod.rs
+++ b/gpt_disk_io/tests/common/mod.rs
@@ -42,7 +42,7 @@ where
 
     // Debug/Display
     assert!(!format!("{a:?}").is_empty());
-    format!("{a}");
+    let _ = format!("{a}");
 
     // Hash
     let mut hasher = DefaultHasher::new();


### PR DESCRIPTION
This code is just making sure that `Display` can be called without panicking; there's no useful check we can run on the result of `format`.