### PR TITLE
gpt_disk_types: Fix indentation of list

### DIFF
--- a/gpt_disk_types/src/lib.rs
+++ b/gpt_disk_types/src/lib.rs
@@ -42,8 +42,8 @@
 //! # Features
 //!
 //! * `bytemuck`: Implements bytemuck's `Pod` and `Zeroable` traits for
-//!    many of the types in this crate. Also enables some methods that
-//!    rely on byte access.
+//!   many of the types in this crate. Also enables some methods that
+//!   rely on byte access.
 //! * `std`: Provides `std::error::Error` implementations for all of the
 //!   error types. Off by default.
 //!


### PR DESCRIPTION
This was caught by clippy 1.86 (currently on the beta channel).