### PR TITLE
Bump workspace MSRV to 1.81

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,8 +24,7 @@ jobs:
     name: MSRV
     runs-on: ubuntu-latest
     env:
-      rust_version: "1.68"
-      CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
+      rust_version: "1.81"
     steps:
       - uses: actions/checkout@v4
       - run: rustup toolchain install $rust_version --profile minimal --no-self-update

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ resolver = "2"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/google/gpt-disk-rs"
-rust-version = "1.68"
+rust-version = "1.81"
 
 [workspace.dependencies]
 bytemuck = { version = "1.4.0", default-features = false }

--- a/gpt_disk_io/CHANGELOG.md
+++ b/gpt_disk_io/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* MSRV increased to 1.81.
+
 # 0.16.1
 
 * Derive `PartialEq` for `DiskError`.

--- a/gpt_disk_io/README.md
+++ b/gpt_disk_io/README.md
@@ -18,7 +18,7 @@ See also the [`gpt_disk_types`] package.
   
 ## Minimum Supported Rust Version (MSRV)
 
-The current MSRV is 1.68.
+The current MSRV is 1.81.
 
 ## License
 

--- a/gpt_disk_types/CHANGELOG.md
+++ b/gpt_disk_types/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* MSRV increased to 1.81.
+
 # 0.16.0
 
 * Bump MSRV to 1.68.

--- a/gpt_disk_types/README.md
+++ b/gpt_disk_types/README.md
@@ -25,9 +25,7 @@ No features are enabled by default.
   
 ## Minimum Supported Rust Version (MSRV)
 
-The current MSRV is 1.68.
-
-[`dep:`]: https://blog.rust-lang.org/2022/04/07/Rust-1.60.0.html#new-syntax-for-cargo-features
+The current MSRV is 1.81.
 
 ## License
 

--- a/uguid/CHANGELOG.md
+++ b/uguid/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* MSRV increased to 1.81.
+
 # 2.2.0
 
 * Added `Variant` enum and `Guid::variant` method.

--- a/uguid/README.md
+++ b/uguid/README.md
@@ -18,7 +18,7 @@ No features are enabled by default.
 
 ## Minimum Supported Rust Version (MSRV)
 
-The current MSRV is 1.68.
+The current MSRV is 1.81.
 
 ## License
 


### PR DESCRIPTION
Rust stablized `core::error::Error` in 1.81, so this will allow us to unconditionally implement that trait for error types without requiring std.