### PR TITLE
uguid: Unconditionally use the Error trait

### DIFF
--- a/uguid/CHANGELOG.md
+++ b/uguid/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 * MSRV increased to 1.81.
+* The `Error` trait is now unconditionally implemented for `GuidFromStrError`.
 
 # 2.2.0
 

--- a/uguid/README.md
+++ b/uguid/README.md
@@ -14,7 +14,7 @@ No features are enabled by default.
 
 * `bytemuck`: Implements bytemuck's `Pod` and `Zeroable` traits for `Guid`.
 * `serde`: Implements serde's `Serialize` and `Deserialize` traits for `Guid`.
-* `std`: Provides `std::error::Error` implementation for the error type.
+* `std`: Currently has no effect.
 
 ## Minimum Supported Rust Version (MSRV)
 

--- a/uguid/src/error.rs
+++ b/uguid/src/error.rs
@@ -10,10 +10,6 @@ use core::fmt::{self, Display, Formatter};
 
 /// Error type for [`Guid::try_parse`] and [`Guid::from_str`].
 ///
-/// If the `std` feature is enabled, this type implements the [`Error`]
-/// trait.
-///
-/// [`Error`]: std::error::Error
 /// [`Guid::from_str`]: core::str::FromStr::from_str
 /// [`Guid::try_parse`]: crate::Guid::try_parse
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
@@ -53,3 +49,5 @@ impl Display for GuidFromStrError {
         }
     }
 }
+
+impl core::error::Error for GuidFromStrError {}

--- a/uguid/src/lib.rs
+++ b/uguid/src/lib.rs
@@ -23,7 +23,7 @@
 //!
 //! * `bytemuck`: Implements bytemuck's `Pod` and `Zeroable` traits for `Guid`.
 //! * `serde`: Implements serde's `Serialize` and `Deserialize` traits for `Guid`.
-//! * `std`: Provides `std::error::Error` implementation for the error type.
+//! * `std`: Currently has no effect.
 //!
 //! # Examples
 //!
@@ -82,7 +82,7 @@
 //! );
 //! ```
 
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![warn(missing_copy_implementations)]
 #![warn(missing_debug_implementations)]
@@ -115,9 +115,6 @@ mod util;
 
 pub use error::GuidFromStrError;
 pub use guid::{Guid, Variant};
-
-#[cfg(feature = "std")]
-impl std::error::Error for GuidFromStrError {}
 
 /// Create a [`Guid`] from a string at compile time.
 ///


### PR DESCRIPTION
The `std` feature doesn't do anything anymore, but keep it around to avoid a major version bump for the next release. (And it might be useful for other things in the future.)