### PR TITLE
uguid: Fix compilation tests for guid macro

### DIFF
--- a/uguid/tests/ui/guid_hex.stderr
+++ b/uguid/tests/ui/guid_hex.stderr
@@ -2,6 +2,6 @@ error[E0080]: evaluation of constant value failed
   --> tests/ui/guid_hex.rs:12:14
    |
 12 |     let _g = guid!("g1234567-89ab-cdef-0123-456789abcdef");
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'GUID string contains one or more invalid characters', $DIR/tests/ui/guid_hex.rs:12:14
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation panicked: GUID string contains one or more invalid characters
    |
    = note: this error originates in the macro `guid` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/uguid/tests/ui/guid_len.stderr
+++ b/uguid/tests/ui/guid_len.stderr
@@ -2,6 +2,6 @@ error[E0080]: evaluation of constant value failed
   --> tests/ui/guid_len.rs:12:14
    |
 12 |     let _g = guid!("1234");
-   |              ^^^^^^^^^^^^^ the evaluated program panicked at 'GUID string has wrong length (expected 36 bytes)', $DIR/tests/ui/guid_len.rs:12:14
+   |              ^^^^^^^^^^^^^ evaluation panicked: GUID string has wrong length (expected 36 bytes)
    |
    = note: this error originates in the macro `guid` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/uguid/tests/ui/guid_sep.stderr
+++ b/uguid/tests/ui/guid_sep.stderr
@@ -2,6 +2,6 @@ error[E0080]: evaluation of constant value failed
   --> tests/ui/guid_sep.rs:12:14
    |
 12 |     let _g = guid!("01234567089ab-cdef-0123-456789abcdef");
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'GUID string is missing one or more separators (`-`)', $DIR/tests/ui/guid_sep.rs:12:14
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation panicked: GUID string is missing one or more separators (`-`)
    |
    = note: this error originates in the macro `guid` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
The error text changed in Rust 1.87:
https://github.com/rust-lang/rust/pull/136503