### PR TITLE
uguid: Update compilation error tests

### DIFF
--- a/uguid/tests/ui/guid_hex.stderr
+++ b/uguid/tests/ui/guid_hex.stderr
@@ -1,7 +1,7 @@
-error[E0080]: evaluation of constant value failed
+error[E0080]: evaluation panicked: GUID string contains one or more invalid characters
   --> tests/ui/guid_hex.rs:12:14
    |
 12 |     let _g = guid!("g1234567-89ab-cdef-0123-456789abcdef");
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation panicked: GUID string contains one or more invalid characters
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `main::G` failed here
    |
    = note: this error originates in the macro `guid` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/uguid/tests/ui/guid_len.stderr
+++ b/uguid/tests/ui/guid_len.stderr
@@ -1,7 +1,7 @@
-error[E0080]: evaluation of constant value failed
+error[E0080]: evaluation panicked: GUID string has wrong length (expected 36 bytes)
   --> tests/ui/guid_len.rs:12:14
    |
 12 |     let _g = guid!("1234");
-   |              ^^^^^^^^^^^^^ evaluation panicked: GUID string has wrong length (expected 36 bytes)
+   |              ^^^^^^^^^^^^^ evaluation of `main::G` failed here
    |
    = note: this error originates in the macro `guid` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/uguid/tests/ui/guid_sep.stderr
+++ b/uguid/tests/ui/guid_sep.stderr
@@ -1,7 +1,7 @@
-error[E0080]: evaluation of constant value failed
+error[E0080]: evaluation panicked: GUID string is missing one or more separators (`-`)
   --> tests/ui/guid_sep.rs:12:14
    |
 12 |     let _g = guid!("01234567089ab-cdef-0123-456789abcdef");
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation panicked: GUID string is missing one or more separators (`-`)
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `main::G` failed here
    |
    = note: this error originates in the macro `guid` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
The output of `guid` failures has changed in rust 1.89, update the test expectations. Unfortunately the output is now a little worse (it references the internal `G` constant, which is not useful to display to the end user), but that seems unavoidable for now.