### PR TITLE
Replace doc_auto_cfg with doc_cfg

### DIFF
--- a/gpt_disk_io/src/lib.rs
+++ b/gpt_disk_io/src/lib.rs
@@ -118,7 +118,7 @@
 //! [`EFI_BLOCK_IO_PROTOCOL`]: https://uefi.org/specs/UEFI/2.10/13_Protocols_Media_Access.html#block-i-o-protocol
 
 #![cfg_attr(not(feature = "std"), no_std)]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![warn(missing_docs)]
 #![warn(trivial_casts)]
 #![warn(trivial_numeric_casts)]

--- a/gpt_disk_types/src/lib.rs
+++ b/gpt_disk_types/src/lib.rs
@@ -85,7 +85,7 @@
 //! ```
 
 #![no_std]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![warn(missing_copy_implementations)]
 #![warn(missing_debug_implementations)]
 #![warn(missing_docs)]

--- a/uguid/src/lib.rs
+++ b/uguid/src/lib.rs
@@ -83,7 +83,7 @@
 //! ```
 
 #![no_std]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![warn(missing_copy_implementations)]
 #![warn(missing_debug_implementations)]
 #![warn(missing_docs)]


### PR DESCRIPTION
The `doc_auto_cfg` feature has been subsumed by `doc_cfg`: https://github.com/rust-lang/rust/pull/138907